### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ If you find PyTorch3D useful in your research, please cite our tech report:
 }
 ```
 
-If you are using the pulsar backend for sphere-rendering (the `PulsarPointRenderer` or `pytorch3d.renderer.points.pulsar.Renderer`), please cite the tech report:
+If you are using the pulsar backend for sphere-rendering (the `PulsarPointRenderer` or `pytorch3d.renderer.points.pulsar.Renderer`), please cite the technical report:
 
 ```bibtex
 @article{lassner2020pulsar,


### PR DESCRIPTION
The word "tech report" should be "technical report" to make the sentence more grammatically correct. It should be:

"If you are using the pulsar backend for sphere-rendering (the PulsarPointRenderer or pytorch3d.renderer.points.pulsar.Renderer), please cite the technical report:"

This change ensures that the text is grammatically accurate.